### PR TITLE
Change to Digest API

### DIFF
--- a/rakuguide.adoc
+++ b/rakuguide.adoc
@@ -2836,13 +2836,14 @@ Now, run the below script:
 [source,perl6]
 ----
 use Digest::MD5;
+
 my $password = "password123";
-my $hashed-password = Digest::MD5.new.md5_hex($password);
+my $hashed-password = md5( $password );
 
 say $hashed-password;
 ----
 In order to run the `md5_hex()` function that creates hashes, we need to load the required module. +
-The `use` keyword loads the module for use in the script.
+The `use` keyword loads the module for use in the script whic provides an `md5` subroutine.
 
 WARNING: In practice MD5 hashing alone is not sufficient, because it is prone to dictionary attacks. +
 It should be combined with a salt link:https://en.wikipedia.org/wiki/Salt_(cryptography)[https://en.wikipedia.org/wiki/Salt_(cryptography)].


### PR DESCRIPTION
As mentioned here https://github.com/ugexe/zef/issues/558 and here https://github.com/grondilu/libdigest-raku/issues/40 this patch updates the example code to use the most recent MD5 as provided by ```zef install Digest::MD5``` to prevent a failure when the code is run